### PR TITLE
Revert "Update Jekyll-Geolexica dependency and config"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/geolexica/geolexica-server.git
-  revision: cbd7efb18e46ba318b82bda9cb355747021c6150
+  revision: 5b29e4de1cc2e20b869a81e08c0cdf2b3bf9b339
   specs:
     jekyll-geolexica (0.1.0)
       jekyll (~> 3.8.5)
@@ -88,4 +88,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.1.4
+   2.0.2

--- a/_config.yml
+++ b/_config.yml
@@ -4,17 +4,9 @@ google_analytics:
   id: UA-138578173-2
 
 committee:
-  identifier: TC 211
+  id: 211
   name: Geographic information/Geomatics
-  parent_org_name: ISO
   home: https://committee.iso.org/home/tc211
-  main_logo:
-    path: /assets/logo-iso-noninverted.svg
-    alt_text: ISO
-  footer_logo:
-    path: /assets/logo-iso-noninverted.svg
-    alt_text: ISO organization
-    url: https://www.iso.org/
 
 font_awesome_kit_url: https://kit.fontawesome.com/77a8a07e0a.js
 


### PR DESCRIPTION
Reverts ISO-TC211/isotc211.geolexica.org#100.

Something broke, and I didn't notice it before. Reverting for now.