### PR TITLE
Bring back the feedback page

### DIFF
--- a/_pages/feedback.adoc
+++ b/_pages/feedback.adoc
@@ -1,0 +1,13 @@
+---
+layout: base-page
+title: Feedback
+permalink: /feedback/
+bodyClass: page
+nav_items: [concepts, posts, stats, registers, about]
+---
+Please feel free to send your thoughts about Geolexica,
+bug reports, or just kudos, through the form below. Thanks!
+
+++++
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScdRwjGvHl1r4DamABqb1uQp7MQdsB-1s3vZHPBiKIKVNFMlQ/viewform?embedded=true" width="640" height="871" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+++++


### PR DESCRIPTION
Feedback page belongs to specific sites (like this one), hence it has been removed from Jekyll-Geolexica as of https://github.com/geolexica/geolexica-server/pull/32.
