### PR TITLE
Move copyright to About page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/geolexica/geolexica-server.git
-  revision: 1a099c5555b8350edd9beb81cd4b8a2a4084f9de
+  revision: 40a02b4ce56a69b17a192897c2bcb95889735a6e
   specs:
     jekyll-geolexica (0.1.0)
       jekyll (~> 3.8.5)

--- a/_config.yml
+++ b/_config.yml
@@ -30,19 +30,6 @@ tagline: >-
 description: >-
   The authoritative glossary for geographic information technology from ISO/TC 211.
 
-# Used for copyright notice and possibly more.
-org:
-  name: International Organization for Standardization
-  website:
-    url: https://www.iso.org/
-    title: www.iso.org
-  email: copyright@iso.org
-  address: |-
-    Chemin de Blandonnet 8
-    CP 401
-    1214 Vernier, Geneva
-    Switzerland
-
 baseurl: ""
 url: "https://www.geolexica.org"
 

--- a/_pages/about.adoc
+++ b/_pages/about.adoc
@@ -68,3 +68,22 @@ link:/feedback[Feedback] page.
 Identified issues that are publicly visible are maintained at the
 https://github.com/ISO-TC211/TMG/issues[TMG GitHub Issues] page.
 
+
+== Copyright
+
+(C) {{ site.time | date: "%Y" }} International Organization for Standardization.
+
+All rights reserved. Unless otherwise specified, no part of this
+site or its documents may be reproduced or utilized otherwise in any form or by any
+means, electronic or mechanical, including photocopying, or posting on the
+internet or an intranet, without prior written permission. Permission can
+be requested from the address below.
+
+[%hardbreaks]
+International Organization for Standardization
+Chemin de Blandonnet 8
+CP 401
+1214 Vernier, Geneva
+Switzerland
+mailto:copyright@iso.org[copyright@iso.org]
+https://www.iso.org/[www.iso.org]


### PR DESCRIPTION
- Add copyright section to About page.
- Update Geolexica to newest version.
- Delete now unused copyright settings from `_config.yml`, see: https://github.com/geolexica/geolexica-server/pull/47.
