### PR TITLE
Tidy up generated JSONs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :jekyll_plugins do
   gem "jekyll-data"
   gem "jekyll-sitemap"
   gem "jekyll-asciidoc"
+  gem "jekyll-tidy-json"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-theme-isotc211-helpers (0.5.4)
       jekyll (~> 3.8)
+    jekyll-tidy-json (1.0.0)
+      jekyll (>= 3.8, < 5)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -85,6 +87,7 @@ DEPENDENCIES
   jekyll-plugin-frontend-build (~> 0.0.2)
   jekyll-sitemap
   jekyll-theme-isotc211-helpers (~> 0.5.4)
+  jekyll-tidy-json
   tzinfo-data
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -151,6 +151,9 @@ geolexica:
     - json-ld
     - turtle
 
+tidy_json:
+  pretty: true
+
 exclude:
   - geolexica-database/
   - README.adoc


### PR DESCRIPTION
Use [Jekyll-Tidy-JSON](https://github.com/geolexica/jekyll-tidy-json) to prettify generated JSONs (easier to spot differences in Git), and to ensure that they are not malformed.